### PR TITLE
Bound Unitful version until Unitful 0.13 is released.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 1
-Unitful
+Unitful 0.12 0.13-


### PR DESCRIPTION
A change to the type signature of `Quantity` is causing a few packages to fail tests, this one included. I'm submitting some PRs to those packages to upper-bound the Unitful version. Please merge and tag a new minor release (0.5.0). I'll submit a separate PR with the changes you'd need to merge once Unitful 0.13 is released.