### PR TITLE
add 'as' as arcsecond for alias with prefixes enabled

### DIFF
--- a/src/UnitfulAngles.jl
+++ b/src/UnitfulAngles.jl
@@ -7,21 +7,23 @@ import Base: sin, cos, tan, sec, csc, cot, asin, acos, atan, asec, acsc, acot, c
 
 
 ######################### Angle units ##########################################
-@unit turn          "τ"             Turn          2π*u"rad"     false
-@unit doubleTurn    "§"             DoubleTurn    2turn         false
-@unit halfTurn      "π"             HalfTurn      turn//2       false
-@unit quadrant      "⦜"             Quadrant      turn//4       false
-@unit sextant       "sextant"       Sextant       turn//6       false
-@unit octant        "octant"        Octant        turn//8       false
-@unit clockPosition "clockPosition" ClockPosition turn//12      false
-@unit hourAngle     "hourAngle"     HourAngle     turn//24      false
-@unit compassPoint  "compassPoint"  CompassPoint  turn//32      false
-@unit hexacontade   "hexacontade"   Hexacontade   turn//60      false
-@unit brad          "brad"          BinaryRadian  turn//256     false
-@unit diameterPart  "diameterPart"  DiameterPart  1u"rad"/60    false # ≈ turn/377
-@unit grad          "ᵍ"             Gradian       turn//400     false
-@unit arcminute     "′"             Arcminute     u"°"//60      false # = turn/21,600
-@unit arcsecond     "″"             Arcsecond     u"°"//3600    false # = turn/1,296,000
+@unit turn          "τ"             Turn           2π*u"rad"     false
+@unit doubleTurn    "§"             DoubleTurn     2turn         false
+@unit halfTurn      "π"             HalfTurn       turn//2       false
+@unit quadrant      "⦜"             Quadrant       turn//4       false
+@unit sextant       "sextant"       Sextant        turn//6       false
+@unit octant        "octant"        Octant         turn//8       false
+@unit clockPosition "clockPosition" ClockPosition  turn//12      false
+@unit hourAngle     "hourAngle"     HourAngle      turn//24      false
+@unit compassPoint  "compassPoint"  CompassPoint   turn//32      false
+@unit hexacontade   "hexacontade"   Hexacontade    turn//60      false
+@unit brad          "brad"          BinaryRadian   turn//256     false
+@unit diameterPart  "diameterPart"  DiameterPart   1u"rad"/60    false # ≈ turn/377
+@unit grad          "ᵍ"             Gradian        turn//400     false
+@unit arcminute     "′"             Arcminute      u"°"//60      false # = turn/21,600
+@unit arcsecond     "″"             Arcsecond      u"°"//3600    false # = turn/1,296,000
+# enable shorthand for arcseconds: e.g., 'mas' - milliarcsecond
+@unit as            "as"            ArcsecondShort u"°"//3600    true
 
 ######################### Functions ############################################
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ using Unitful, UnitfulAngles
 import Dates
 using Test
 
-units = (u"doubleTurn", u"turn", u"halfTurn", u"quadrant", u"sextant", u"octant", u"clockPosition", u"hourAngle", u"compassPoint", u"hexacontade", u"brad", u"°", u"grad", u"arcminute", u"arcsecond", u"rad", u"diameterPart")
-quantities = (0.5, 1, 2, 4, 6, 8, 12, 24, 32, 60, 256, 360, 400, 21600, 1296000, 2π, 120π)
+units = (u"doubleTurn", u"turn", u"halfTurn", u"quadrant", u"sextant", u"octant", u"clockPosition", u"hourAngle", u"compassPoint", u"hexacontade", u"brad", u"°", u"grad", u"arcminute", u"arcsecond", u"as", u"rad", u"diameterPart")
+quantities = (0.5, 1, 2, 4, 6, 8, 12, 24, 32, 60, 256, 360, 400, 21600, 1296000, 1296000, 2π, 120π)
 
 @test all(1u"turn" ≈ q*u for (q, u) in zip(quantities, units))
 for _f in (:sin, :cos, :tan, :sec, :csc, :cot), (q, u) in zip(quantities, units), a in 13:17
@@ -12,6 +12,15 @@ end
 
 for (_f, _x) in zip((:asin, :acos, :atan, :asec, :acsc, :acot), (.5, √3/2, √3/3, 2/√3, 2, √3))
     @test @eval $_f(u"°", $_x) ≈ 30u"°"
+end
+
+# specific tests for 'as' - make sure prefixes work (all values should be equal to 1 arcsecond)
+for qty in (1e24u"yas", 1e21u"zas", 1e18u"aas", 1e15u"fas", 1e12u"pas", 1e9u"nas", 1e6u"μas", 1e6u"µas", 1e3u"mas",
+            1e2u"cas", 10u"das", 1u"as", 1e-1u"daas", 1e-2u"has", 1e-3u"kas", 1e-6u"Mas", 1e-9u"Gas", 1e-12u"Tas",
+            1e-15u"Pas", 1e-18u"Eas", 1e-21u"Zas", 1e-24u"Yas")
+    for _f in (sin, cos, tan, sec, csc, cot)
+        @test  _f(qty) ≈ _f(deg2rad(1/3600))
+    end
 end
 
 @test atan(u"°", 1,1) == 45u"°"


### PR DESCRIPTION
It is extremely common in astronomy to use arcseconds. Very commonly, we work with quantities like "milliarcseconds" and "microarcseconds" for the super small angles on the night sky. We've run into this issue in (https://github.com/JuliaAstro/UnitfulAstro.jl/pull/7). This PR adds a *new* unit `"as"` (`ArcsecondShort` struct name) which has prefixes enabled. The following conversions are now trivial-

```julia
julia> using Unitful, UnitfulAngles

julia> plate_scale = 0.91u"mas/mm"
0.91 mas mm⁻¹

julia> plate_scale |> u"rad/m"
4.411804498096778e-6 rad m⁻¹

julia> ustrip(ans) ≈ deg2rad(ustrip(plate_scale) * 1e3 / 3.6e6)
true
```

I've also added `as` to the testing units, and have added extra tests to ensure the prefixes are accurate alongside what Unitful provides.

## Current Problems

There are two problems to address that I would like feedback on, if possible

* `u"as"` is technically valid as "attoseconds". I don't know a good workaround for this- if there was a way to disable `u"as"` while still allowing, e.g., `u"mas"` that would be perfect, since it's easy enough to write out `u"arcsecond"` if the prefix isn't needed.
* I can't find any clear examples of essentially aliasing a unit in Unitful.jl, although we are aliasing `Arcsecond` with this new `ArcsecondShort` unit. I don't know if this is the appropriate way and I don't love it, since it seems very easy to get mixed up. 

One of the alternatives would be adding two bespoke units for millarcsecond and microarcsecond, but that feels very ad-hoc and adds more potential for bugs between the three Unitful libraries I've mentioned

