### PR TITLE
Redefine sub-arcsecond units

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "UnitfulAngles"
 uuid = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
-version = "0.6.2"
+version = "0.7.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/UnitfulAngles.jl
+++ b/src/UnitfulAngles.jl
@@ -7,28 +7,28 @@ import Unitful: rad, °
 import Base: sin, cos, tan, sec, csc, cot, asin, acos, atan, asec, acsc, acot, convert
 
 
-######################### Angle units ##########################################
-@unit turn          "τ"             Turn           2π*rad                   false
-@unit doubleTurn    "§"             DoubleTurn     2turn                    false
-@unit halfTurn      "π"             HalfTurn       turn//2                  false
-@unit quadrant      "⦜"             Quadrant       turn//4                  false
-@unit sextant       "sextant"       Sextant        turn//6                  false
-@unit octant        "octant"        Octant         turn//8                  false
-@unit clockPosition "clockPosition" ClockPosition  turn//12                 false
-@unit hourAngle     "hourAngle"     HourAngle      turn//24                 false
-@unit compassPoint  "compassPoint"  CompassPoint   turn//32                 false
-@unit hexacontade   "hexacontade"   Hexacontade    turn//60                 false
-@unit brad          "brad"          BinaryRadian   turn//256                false
-@unit diameterPart  "diameterPart"  DiameterPart   rad//60                  false # ≈ turn/377
-@unit grad          "ᵍ"             Gradian        turn//400                false
-@unit arcminute     "′"             Arcminute      °//60                    false # = turn/21,600
-@unit arcsecond     "″"             Arcsecond      °//3600                  false # = turn/1,296,000
+######################### Angle units ############################################
+@unit turn           "τ"             Turn           2π*rad                   false
+@unit doubleTurn     "§"             DoubleTurn     2turn                    false
+@unit halfTurn       "π"             HalfTurn       turn//2                  false
+@unit quadrant       "⦜"             Quadrant       turn//4                  false
+@unit sextant        "sextant"       Sextant        turn//6                  false
+@unit octant         "octant"        Octant         turn//8                  false
+@unit clockPosition  "clockPosition" ClockPosition  turn//12                 false
+@unit hourAngle      "hourAngle"     HourAngle      turn//24                 false
+@unit compassPoint   "compassPoint"  CompassPoint   turn//32                 false
+@unit hexacontade    "hexacontade"   Hexacontade    turn//60                 false
+@unit brad           "brad"          BinaryRadian   turn//256                false
+@unit diameterPart   "diameterPart"  DiameterPart   rad//60                  false # ≈ turn/377
+@unit grad           "ᵍ"             Gradian        turn//400                false
+@unit arcminute      "′"             Arcminute      °//60                    false # = turn/21,600
+@unit arcsecond      "″"             Arcsecond      °//3600                  false # = turn/1,296,000
 # enable shorthand for arcseconds: e.g., 'mas' - milliarcsecond
-@unit mas           "mas"           Milliarcsecond Arcsecond//1_000         false 
-@unit μas           "μas"           Microarcsecond Arcsecond//1_000_000     false 
-@unit μas           "pas"           Picoarcsecond  Arcsecond//1_000_000_000 false
+@unit mas            "mas"           Milliarcsecond arcsecond//1_000         false 
+@unit μas            "μas"           Microarcsecond arcsecond//1_000_000     false 
+@unit pas            "pas"           Picoarcsecond  arcsecond//1_000_000_000 false
 
-######################### Functions ############################################
+######################### Functions ##############################################
 
 # cos and sin have *pi versions, and *d versions
 for _f in (:cos, :sin)

--- a/src/UnitfulAngles.jl
+++ b/src/UnitfulAngles.jl
@@ -8,23 +8,25 @@ import Base: sin, cos, tan, sec, csc, cot, asin, acos, atan, asec, acsc, acot, c
 
 
 ######################### Angle units ##########################################
-@unit turn          "τ"             Turn           2π*rad        false
-@unit doubleTurn    "§"             DoubleTurn     2turn         false
-@unit halfTurn      "π"             HalfTurn       turn//2       false
-@unit quadrant      "⦜"             Quadrant       turn//4       false
-@unit sextant       "sextant"       Sextant        turn//6       false
-@unit octant        "octant"        Octant         turn//8       false
-@unit clockPosition "clockPosition" ClockPosition  turn//12      false
-@unit hourAngle     "hourAngle"     HourAngle      turn//24      false
-@unit compassPoint  "compassPoint"  CompassPoint   turn//32      false
-@unit hexacontade   "hexacontade"   Hexacontade    turn//60      false
-@unit brad          "brad"          BinaryRadian   turn//256     false
-@unit diameterPart  "diameterPart"  DiameterPart   rad//60       false # ≈ turn/377
-@unit grad          "ᵍ"             Gradian        turn//400     false
-@unit arcminute     "′"             Arcminute      °//60         false # = turn/21,600
-@unit arcsecond     "″"             Arcsecond      °//3600       false # = turn/1,296,000
+@unit turn          "τ"             Turn           2π*rad                   false
+@unit doubleTurn    "§"             DoubleTurn     2turn                    false
+@unit halfTurn      "π"             HalfTurn       turn//2                  false
+@unit quadrant      "⦜"             Quadrant       turn//4                  false
+@unit sextant       "sextant"       Sextant        turn//6                  false
+@unit octant        "octant"        Octant         turn//8                  false
+@unit clockPosition "clockPosition" ClockPosition  turn//12                 false
+@unit hourAngle     "hourAngle"     HourAngle      turn//24                 false
+@unit compassPoint  "compassPoint"  CompassPoint   turn//32                 false
+@unit hexacontade   "hexacontade"   Hexacontade    turn//60                 false
+@unit brad          "brad"          BinaryRadian   turn//256                false
+@unit diameterPart  "diameterPart"  DiameterPart   rad//60                  false # ≈ turn/377
+@unit grad          "ᵍ"             Gradian        turn//400                false
+@unit arcminute     "′"             Arcminute      °//60                    false # = turn/21,600
+@unit arcsecond     "″"             Arcsecond      °//3600                  false # = turn/1,296,000
 # enable shorthand for arcseconds: e.g., 'mas' - milliarcsecond
-@unit as            "as"            ArcsecondShort °//3600       true
+@unit mas           "mas"           Milliarcsecond Arcsecond//1_000         false 
+@unit μas           "μas"           Microarcsecond Arcsecond//1_000_000     false 
+@unit μas           "pas"           Picoarcsecond  Arcsecond//1_000_000_000 false
 
 ######################### Functions ############################################
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,9 @@ using Unitful, UnitfulAngles
 import Dates
 using Test
 
-units = (u"doubleTurn", u"turn", u"halfTurn", u"quadrant", u"sextant", u"octant", u"clockPosition", u"hourAngle", u"compassPoint", u"hexacontade", u"brad", u"°", u"grad", u"arcminute", u"arcsecond", u"as", u"rad", u"diameterPart")
-quantities = (0.5, 1, 2, 4, 6, 8, 12, 24, 32, 60, 256, 360, 400, 21600, 1296000, 1296000, 2π, 120π)
+units = (u"doubleTurn", u"turn", u"halfTurn", u"quadrant", u"sextant", u"octant", u"clockPosition", u"hourAngle", u"compassPoint", u"hexacontade", u"brad", u"°", u"grad", u"arcminute", u"arcsecond", u"mas", u"μas", u"pas", u"rad", u"diameterPart",
+)
+quantities = (0.5, 1, 2, 4, 6, 8, 12, 24, 32, 60, 256, 360, 400, 21600, 1296000, 1296e6, 1296e9, 1296e12, 2π, 120π)
 
 @test all(1u"turn" ≈ q*u for (q, u) in zip(quantities, units))
 for _f in (:sin, :cos, :tan, :sec, :csc, :cot), (q, u) in zip(quantities, units), a in 13:17
@@ -12,15 +13,6 @@ end
 
 for (_f, _x) in zip((:asin, :acos, :atan, :asec, :acsc, :acot), (.5, √3/2, √3/3, 2/√3, 2, √3))
     @test @eval $_f(u"°", $_x) ≈ 30u"°"
-end
-
-# specific tests for 'as' - make sure prefixes work (all values should be equal to 1 arcsecond)
-for qty in (1e24u"yas", 1e21u"zas", 1e18u"aas", 1e15u"fas", 1e12u"pas", 1e9u"nas", 1e6u"μas", 1e6u"µas", 1e3u"mas",
-            1e2u"cas", 10u"das", 1u"as", 1e-1u"daas", 1e-2u"has", 1e-3u"kas", 1e-6u"Mas", 1e-9u"Gas", 1e-12u"Tas",
-            1e-15u"Pas", 1e-18u"Eas", 1e-21u"Zas", 1e-24u"Yas")
-    for _f in (sin, cos, tan, sec, csc, cot)
-        @test  _f(qty) ≈ _f(deg2rad(1/3600))
-    end
 end
 
 @test atan(u"°", 1,1) == 45u"°"


### PR DESCRIPTION
Following discussion at https://github.com/JuliaAstro/UnitfulAstro.jl/pull/7#issuecomment-1257075848 I think it is reasonable to switch from the `ArcsecondShort` methodology to specifically defining milli-, micro-, and picoarcsecond units directly. This avoids unit clashes, doesn't negatively affect the user-interface, and covers a large majority of use-cases.
